### PR TITLE
Add script for packaging docsets into release archives and generating feed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+dist

--- a/feeds/core.xml
+++ b/feeds/core.xml
@@ -1,0 +1,6 @@
+<entry>
+    <version>2022.12.13</version>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/ros_core.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/rclpy.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/rclcpp.tgz</url>
+<entry>

--- a/feeds/extras.xml
+++ b/feeds/extras.xml
@@ -1,0 +1,6 @@
+<entry>
+    <version>2022.12.13</version>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/Navigation_2.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/MoveIt_documentation.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/ROS_2_documentation.tgz</url>
+<entry>

--- a/feeds/full.xml
+++ b/feeds/full.xml
@@ -1,0 +1,11 @@
+<entry>
+    <version>2022.12.13</version>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/launch.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/Navigation_2.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/ros_core.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/rclpy.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/colcon.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/rclcpp.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/MoveIt_documentation.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/ROS_2_documentation.tgz</url>
+<entry>

--- a/feeds/tools.xml
+++ b/feeds/tools.xml
@@ -1,0 +1,5 @@
+<entry>
+    <version>2022.12.13</version>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/launch.tgz</url>
+    <url>https://github.com/Serafadam/ros_docsets/releases/download/2022.12.13/colcon.tgz</url>
+<entry>

--- a/package_docs.sh
+++ b/package_docs.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Packages docsets into release archives and generates docset feed files.
+set -e  # Terminate on error
+
+BASEDIR=$(realpath $(dirname "${BASH_SOURCE[0]:-$0}"))  # Absolute path to script directory
+DOCSDIR="${BASEDIR}/docsets"                            # Absolute path to docsets
+PKGSDIR="${BASEDIR}/dist"                               # Absolute path for created archives
+FEEDSDIR="${BASEDIR}/feeds"                             # Absolute path for created feeds
+
+BASEURL=https://github.com/Serafadam/ros_docsets/releases/download
+# Feeds
+FEEDS=(
+  core
+  extras
+  tools
+  full
+)
+# Docsets, as {name: feed name}
+declare -A DOCSETS=(
+  ["colcon"]="tools"
+  ["launch"]="tools"
+  ["rclcpp"]="core"
+  ["rclpy"]="core"
+  ["ros_core"]="core"
+  ["MoveIt documentation"]="extras"
+  ["Navigation 2"]="extras"
+  ["ROS 2 documentation"]="extras"
+)
+VERSION=
+
+
+# Prints script usage help.
+print_usage() {
+  echo "Usage: ${BASH_SOURCE[0]##*/} [--version VERSION]
+
+Packages docsets into release archives and generates docset feed files.
+
+Version defaults to docsets last commit date, or current date if docsets locally modified.
+
+optional arguments:
+  --version VERSION    explicit version to use
+"
+}
+
+
+# Parse script parameters
+while (( "$#" )); do
+  case "$1" in
+    --version)
+      VERSION="$2"
+      shift 2
+    ;;
+    -h|--help)
+      print_usage
+      exit
+    ;;
+    *)  # unsupported flags
+      echo "Error: unknown parameter $1" >&2
+      exit 1
+    ;;
+  esac
+done
+
+
+# Ensure version
+if [[ -z "$VERSION" ]] ; then
+  # Set version to docsets last commit date if not locally modified
+  if [[ -z `git -C "$BASEDIR" status $(basename "$DOCSDIR") --short` ]] ; then
+    VERSION=$(git -C "$BASEDIR" log -1 --format=%cd --date=format:'%Y.%m.%d' $(basename "$DOCSDIR"))
+  fi
+fi
+if [[ -z "$VERSION" ]] ; then
+  VERSION=$(date +'%Y.%m.%d')
+fi
+
+
+echo "Creating archives and feeds for version $VERSION"
+echo
+mkdir -p "$PKGSDIR"
+mkdir -p "$FEEDSDIR"
+
+# Create docset archives
+for docset in "${!DOCSETS[@]}" ; do
+  echo -n "Archiving ${docset}.."
+  filepath="${PKGSDIR}/${docset// /_}.tgz"
+  tar -cvzf "$filepath" -C "$DOCSDIR" "${docset}.docset" >/dev/null
+  echo "  created $(basename "$PKGSDIR")/$(basename "$filepath") ($(du --bytes "$filepath" | cut -f1) bytes)"
+done
+
+# Create feeds
+for feed in "${FEEDS[@]}" ; do
+  filepath="${FEEDSDIR}/${feed}.xml"
+  echo "Creating $(basename "$FEEDSDIR")/$(basename "$filepath")"
+  echo "<entry>" > "$filepath"
+  echo "    <version>$VERSION</version>" >> "$filepath"
+  for docset in "${!DOCSETS[@]}" ; do
+    if [[ "$feed" == "full" ]] || [[ "$feed" == "${DOCSETS[$docset]}" ]] ; then
+      echo "    <url>$BASEURL/$VERSION/${docset// /_}.tgz</url>" >> "$filepath"
+    fi
+  done
+  echo "<entry>" >> "$filepath"
+done


### PR DESCRIPTION
First of all I'd like to say: thank you for making this! :heart:  The official state of ROS2 documentation availability has been shameful. 

What would make this even better, if it provided feed URLs that could just be imported in Zeal. 


So if you like, here's a script that does that. Upon execution, it will:
- tar and zip the docset folders into individual archives under dist/
- populate feed XML files under feeds/

You would have to make an explicit release in the Github repo and upload the archives to that release. And then people can just provide Zeal with a link to one of the feed files in the repo, like https://github.com/Serafadam/ros_docsets/blob/main/docsets/feeds/full.xml, and Zeal will pull in the docs by itself.


(I suppose in the long run, it would make sense to drop the docsets themselves from this repo and provide the archive releases only, as the repo is already a whopping 2GB and only going to get larger.)